### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,7 @@ A lean, gulp-based HTML & SASS boilerplate for better front-end coding.
 
 - Node.js
     - <http://nodejs.org/>
+    - **v0.10.x** is needed.
 
 ## Set Up
 


### PR DESCRIPTION
nodeの最新安定版である0.12.x系で `npm install` しますと，gulp-pleeease が依存している fsevents のnodeの要求バージョンが古いようで，エラーが出ました．
gulp-pleeeaseのバージョンを1.2.0としたらエラーはおきなかったことと，node v0.10.36では問題はありませんでしたので．nodeのバージョン要求を追加しました．
